### PR TITLE
update to Elm v0.16.0

### DIFF
--- a/app/src/main.elm
+++ b/app/src/main.elm
@@ -41,7 +41,7 @@ update : Action -> Model -> Model
 update action model =
   case action of
     NoOp -> model
-    UpdateTime t -> { model | time<-t }
+    UpdateTime t -> { model | time = t }
 
 -- view
 view : Address Action -> Model -> Html

--- a/app/src/main.elm
+++ b/app/src/main.elm
@@ -4,7 +4,7 @@ import Color exposing (..)
 import Graphics.Collage exposing (..)
 import Graphics.Element exposing (..)
 import Time exposing (..)
-import Signal exposing (Signal, Address, (<~))
+import Signal exposing (Signal, Address)
 
 import Native.Log
 import Native.Unsafe
@@ -14,7 +14,7 @@ import Html.Attributes exposing (style)
 
 draggable = style [("-webkit-app-region","drag")]
 
-main = (view actions.address) <~ model
+main = Signal.map (view actions.address) model
 
 -- signal handler
 
@@ -22,7 +22,7 @@ model : Signal Model
 model = Signal.foldp update initialModel signals
 
 signals = Signal.mergeMany [ actions.signal
-                           , UpdateTime <~ (Native.Log.log (every second))
+                           , Signal.map UpdateTime (Native.Log.log (every second))
                            ]
 
 actions : Signal.Mailbox Action

--- a/elm-package.json
+++ b/elm-package.json
@@ -9,9 +9,9 @@
     "exposed-modules": [],
     "native-modules": true,
     "dependencies": {
-        "elm-lang/core": "2.1.0 <= v < 3.0.0",
-        "evancz/elm-html": "4.0.1 <= v < 5.0.0",
-        "evancz/start-app": "1.0.1 <= v < 2.0.0"
+        "elm-lang/core": "3.0.0 <= v < 4.0.0",
+        "evancz/elm-html": "4.0.2 <= v < 5.0.0",
+        "evancz/start-app": "2.0.2 <= v < 3.0.0"
     },
-    "elm-version": "0.15.1 <= v < 0.16.0"
+    "elm-version": "0.16.0 <= v < 0.17.0"
 }


### PR DESCRIPTION
`elm make --yes` fails  with elm `0.16.0`

```
Unable to find a set of packages that will work with your constraints
```

I want to use latest Elm, so I changed some updates

- update package information
- update syntax
   - `(<~` was removed from `Signal` in latest `elm-lang/core`
   -  use `=` instead of `<-` in Record update


