### PR TITLE
Fix packaged app cannot find electron-reload

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1,11 +1,14 @@
 const { app, BrowserWindow } = require("electron");
 var mainWindow = null;
+var isDev = process.env.APP_DEV ? (process.env.APP_DEV.trim() == "true") : false;
 
 app.on("window-all-closed", function() {
   app.quit();
 });
 
-require("electron-reload")(__dirname);
+if (isDev) {
+  require("electron-reload")(__dirname);
+}
 
 app.on("ready", function() {
   mainWindow = new BrowserWindow({

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "elmtrn",
   "main": "./app/app.js",
   "scripts": {
-    "start": "electron .",
+    "start": "APP_DEV=true electron .",
     "build": "npm run build:elm",
     "build:elm": "elm make app/src/Main.elm --output app/main.js",
     "init": "elm init",


### PR DESCRIPTION
On windows 10 and Ubuntu 18.04, a packaged app which made by 'npm run
package:all' raises "Cannot find module 'electron-reload'".
<img width="422" alt="elmtrn-error" src="https://user-images.githubusercontent.com/17469634/55286312-12334480-53d5-11e9-8704-9d66e9b68e09.png">
Since 'electron-reload' is not needed for packaged app, I add
if-statement whether to execute `require("electron-reload") to app.js.

ref; https://stackoverflow.com/questions/49278906/electron-deployed-app-not-running-cant-find-module-electron-reload