### PR TITLE
Add cooldown configuration for npm, elm, and GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       time: "09:00"
       timezone: Asia/Tokyo
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 3
   - package-ecosystem: elm
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,5 @@ updates:
       interval: daily
       time: "09:00"
       timezone: Asia/Tokyo
+    cooldown:
+      default-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,8 @@ updates:
       time: "09:00"
       timezone: Asia/Tokyo
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 3
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
Introduce a cooldown period of 3 days for npm, elm, and GitHub Actions updates to manage update frequency.